### PR TITLE
Check if curl is already installed

### DIFF
--- a/d2firewall.sh
+++ b/d2firewall.sh
@@ -137,6 +137,9 @@ install_dependencies () {
 
     # start nginx web service
     service nginx start
+    
+    # check if curl is already installed
+    type curl > /dev/null 2>&1 || DEBIAN_FRONTEND=noninteractive apt-get -y -q install curl > /dev/null
 
     echo -e "${RED}Installing OpenVPN. Please wait while it finishes...${NC}"
     curl -s -O https://raw.githubusercontent.com/angristan/openvpn-install/master/openvpn-install.sh > /dev/null


### PR DESCRIPTION
The curl package is pre-installed on most Linux distributions but not on Ubuntu Desktop 20.04.2.0

- Check if curl is installed and if not then install it. This package is needed to download the file "openvpn-install.sh".
